### PR TITLE
Express 3 update | fatal error correction for Windows developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ e.g.
 ### HTML
       <script src='/js/v0.1.0/app.js' />
 
-There is also a URL versioning helper that will convert paths for you.
+There is also a URL versioning local variable that will convert paths for you.
 You can expose as a helper like so:
 
 ```js
 
 app.configure(function() {
 
-  // This exposes the helper to the views
-  app.helpers({
+  // This exposes the local variable to the views
+  app.locals({
     versionPath: versionator.versionPath
   });
 
@@ -114,8 +114,8 @@ versionator.createMapFromPath(__dirname + '/public', function(error, staticFileM
 
   app.configure(function(){
 
-    // This exposes the helper to the views
-    app.helpers({
+    // This exposes the local variable to the views
+    app.locals({
       versionPath: mappedVersion.versionPath
     });
 

--- a/examples/express-mapped/app.js
+++ b/examples/express-mapped/app.js
@@ -23,7 +23,7 @@ versionator.createMapFromPath(__dirname + '/public', function(error, staticFileM
 
   // Configuration
   app.configure(function(){
-    app.helpers({
+    app.locals({
       versionPath: mappedVersion.versionPath
     });
 

--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -11,7 +11,7 @@ app.configure(function(){
 
   var basic = versionator.createBasic('v' + app.version);
 
-  app.helpers({
+  app.locals({
     versionPath: basic.versionPath
   });
 

--- a/lib/map-path.js
+++ b/lib/map-path.js
@@ -46,7 +46,7 @@ module.exports = function(dirPath, params, callback) {
       hash(filename, function(error, fileHash) {
 
         var
-          urlPath = path.normalize('/' + filename.substring(dirPath.length + 1)),
+          urlPath = path.normalize('/' + filename.substring(dirPath.length + 1)).replace(/\\/g, '/'),
           pos = urlPath.lastIndexOf('/');
 
         hashMap[urlPath] =

--- a/lib/middleware/basic.js
+++ b/lib/middleware/basic.js
@@ -11,7 +11,7 @@ module.exports = function(version) {
     urlPath = urlPath.toString();
     var pos = urlPath.lastIndexOf('/');
     if (pos !== -1) {
-      return path.normalize(urlPath.substring(0, pos) + '/' + version + urlPath.substring(pos));
+      return path.normalize(urlPath.substring(0, pos) + '/' + version + urlPath.substring(pos)).replace(/\\/g, '/');
     } else {
       return urlPath;
     }


### PR DESCRIPTION
Needed to correct the places where path.normalize is used as it causes a fatal error for windows users (you'll probably need to check it still works on Linux now).

Also updated app.helpers to app.locals in the README and examples.

cheers
Andy
