### PR TITLE
Support to escape a directory for mapped version

### DIFF
--- a/lib/middleware/mapped.js
+++ b/lib/middleware/mapped.js
@@ -1,4 +1,4 @@
-module.exports = function(mappedPaths) {
+module.exports = function(mappedPaths, escapedDir) {
 
   var reverseMap = Object.create(null);
 
@@ -44,6 +44,12 @@ module.exports = function(mappedPaths) {
       // We only do this on GET requests
       if (req.method !== 'GET') {
         return next();
+      }
+      if (escapedDir) {
+        if (req.url.indexOf(escapedDir) >= 0) {
+          next();
+          return;
+        }
       }
       req.url = reverseMap[req.url] || req.url;
       next();


### PR DESCRIPTION
You can now do `versionator.createMapped(staticFileMap, 'myEscapedDirectory');`, where the escaped directory will not be reverse-mapped with the hash. This is mostly required to serve CSS files that use resources with relative paths. An example would be select2.css. So I can put select2.css and select2.png in directory `/css/myEscapedDirectory/select2-3.4.1/` and use `link(rel='stylesheet', href='/css/myEscapedDirectory/select2-3.4.1/select2.css)`, and maintain versioning elsewhere.
The implementation looks for the escaped string in req.url, so you can have multiple escaped directories in your file structure (e.g. in both css and javascript directories).
