### PR TITLE
FIX: use stylus nodes api to properly inject url literal

### DIFF
--- a/examples/express-mapped/app.js
+++ b/examples/express-mapped/app.js
@@ -17,7 +17,7 @@ versionator.createMapFromPath(__dirname + '/public', function(error, staticFileM
       .set('warn', true)
       .set('compress', true)
       .define('versionPath', function(urlPath) {
-        return 'url(' + mappedVersion.versionPath(urlPath) + ')';
+        return new stylus.nodes.Literal('url(' + mappedVersion.versionPath(urlPath) + ')');
       });
   }
 

--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -22,7 +22,7 @@ app.configure(function(){
       .set('warn', true)
       .set('compress', true)
       .define('versionPath', function(urlPath) {
-        return 'url(' + basic.versionPath(urlPath) + ')';
+        return new stylus.nodes.Literal('url(' + basic.versionPath(urlPath) + ')');
       });
   }
 


### PR DESCRIPTION
The stylus extension function used within both express example projects is not working.

The background image style is rendering incorrectly as a quoted string.

``` css
#break
{
  background-image: 'url("/images/v0.1/background.png")';
}
```

Stylus provides  a Literal object from the nodes API that can correct this and make it look as follows.

``` css
#break {
  background-image: url("/images/background.png");
}
```
