### PR TITLE
Resolve relative paths

### DIFF
--- a/lib/map-path.js
+++ b/lib/map-path.js
@@ -25,10 +25,14 @@ module.exports = function(dirPath, params, callback) {
     return callback(new Error('Path is required'))
   }
 
+  // resolve '../'s
+  dirPath = path.resolve(dirPath)
+
   // trim trailing slash
   if (dirPath.substring(dirPath.length - 1) === '/') {
     dirPath = dirPath.slice(0, -1);
   }
+
 
   function hash(filename, callback) {
     var
@@ -47,6 +51,10 @@ module.exports = function(dirPath, params, callback) {
   function makeHashMap (callback) {
     var hashMap = Object.create(null)
     async.forEach(files, function(filename, fileCallback) {
+
+      // resolve '../'s
+      filename = path.resolve(filename)
+
       hash(filename, function(error, fileHash) {
 
         var

--- a/test/map-path.test.js
+++ b/test/map-path.test.js
@@ -106,6 +106,30 @@ describe('versionator', function() {
     })
   })
 
+  describe('relative paths', function () {
+
+    it('should resolve relative paths', function(done) {
+
+      versionator.createMapFromPath(tmpPath + '/a/..', function(error, results) {
+
+        var a = {
+          '/a': '/d41d8cd98f00b204e9800998ecf8427e/a',
+          '/b': '/8b1a9953c4611296a827abf8c47804d7/b',
+          '/c': '/e509465ef513154988e088d6ad3c21bf/c',
+          '/sub/a': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a'
+        }
+
+        a.should.eql(results)
+
+        done()
+
+      })
+
+    })
+
+
+  })
+
   after(function(done) {
     removeFiles(tmpPath, files, done)
   })


### PR DESCRIPTION
I came up against this when trying to modularise pliers tasks. `createStaticMap` was happing in a directory beneath public so it had to do some paths like `../public/`. This munged the paths in the output static maps because they weren't resolved first.
