### PR TITLE
Fix crashes when calculating hash of dir symlinks

### DIFF
--- a/lib/map-path.js
+++ b/lib/map-path.js
@@ -87,6 +87,14 @@ module.exports = function(dirPath, params, callback) {
     files.push(filename)
   })
   .on('end', function() {
-    makeHashMap(callback)
+    // Remove symlinks to directories, since directories should not be hashed
+    async.filter(files, function(filename,callback) {
+      fs.stat(filename, function(error, stat) {
+        callback(stat.isFile())
+      })
+    }, function(filteredFiles) {
+      files = filteredFiles
+      makeHashMap(callback)
+    })
   })
 }

--- a/test/map-path.test.js
+++ b/test/map-path.test.js
@@ -3,7 +3,7 @@ var versionator = require('../')
   , mkdirp = require('mkdirp')
   , async = require('async')
 
-function createFiles(dirPath, files, callback) {
+function createFiles(dirPath, files, dirs, callback) {
   var fns = [
     async.apply(mkdirp, dirPath + '/sub')
   ]
@@ -11,16 +11,27 @@ function createFiles(dirPath, files, callback) {
   Object.keys(files).forEach(function(filename) {
     fns.push(async.apply(fs.writeFile, dirPath + '/' + filename, files[filename]))
   })
-
+  Object.keys(files).forEach(function(filename) {
+    fns.push(async.apply(fs.symlink, dirPath + '/' + filename, dirPath + '/' + filename + '_link'))
+  });
+  dirs.forEach(function(dir) {
+    fns.push(async.apply(fs.symlink, dirPath + '/' + dir, dirPath + '/' + dir + '_link'))
+  });
   async.series(fns, callback)
 }
 
-function removeFiles(dirPath, files, callback) {
+function removeFiles(dirPath, files, dirs, callback) {
   var fns = []
 
   Object.keys(files).forEach(function(filename) {
     fns.push(async.apply(fs.unlink, dirPath + '/' + filename))
   })
+  Object.keys(files).forEach(function(filename) {
+    fns.push(async.apply(fs.unlink, dirPath + '/' + filename + '_link'))
+  })
+  dirs.forEach(function(dir) {
+    fns.push(async.apply(fs.unlink, dirPath + '/' + dir + '_link'))
+  });
 
   fns.push(async.apply(fs.rmdir, dirPath + '/sub'))
   fns.push(async.apply(fs.rmdir, dirPath))
@@ -38,9 +49,10 @@ describe('versionator', function() {
       , 'c': 'World!'
       , 'sub/a': 'hi'
       }
+    , dirs = [ 'sub' ]
 
   before(function(done) {
-    createFiles(tmpPath, files, done)
+    createFiles(tmpPath, files, dirs, done)
   })
 
   describe('map path validation', function() {
@@ -53,16 +65,18 @@ describe('versionator', function() {
     })
 
     it('should correctly walk directory and create hashes', function(done) {
-
       versionator.createMapFromPath(tmpPath, function(error, results) {
 
         var a =
           { '/a': '/d41d8cd98f00b204e9800998ecf8427e/a'
+          , '/a_link': '/d41d8cd98f00b204e9800998ecf8427e/a_link'
           , '/b': '/8b1a9953c4611296a827abf8c47804d7/b'
+          , '/b_link': '/8b1a9953c4611296a827abf8c47804d7/b_link'
           , '/c': '/e509465ef513154988e088d6ad3c21bf/c'
+          , '/c_link': '/e509465ef513154988e088d6ad3c21bf/c_link'
           , '/sub/a': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a'
+          , '/sub/a_link': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a_link'
           }
-
         a.should.eql(results)
 
         done()
@@ -87,23 +101,6 @@ describe('versionator', function() {
 
     })
 
-    describe('with a symlink', function() {
-      beforeEach(function(done) {
-        fs.symlink(tmpPath + '/b', tmpPath + '/b_symlink', 'file', done)
-      })
-
-      it('create hash for symlink', function(done) {
-        versionator.createMapFromPath(tmpPath, function(error, results) {
-
-          results['/b_symlink'].should.equal('/8b1a9953c4611296a827abf8c47804d7/b_symlink')
-          done()
-        })
-      })
-
-      afterEach(function(done) {
-        fs.unlink(tmpPath + '/b_symlink', done)
-      })
-    })
   })
 
   describe('relative paths', function () {
@@ -114,9 +111,13 @@ describe('versionator', function() {
 
         var a =
           { '/a': '/d41d8cd98f00b204e9800998ecf8427e/a'
+          , '/a_link': '/d41d8cd98f00b204e9800998ecf8427e/a_link'
           , '/b': '/8b1a9953c4611296a827abf8c47804d7/b'
+          , '/b_link': '/8b1a9953c4611296a827abf8c47804d7/b_link'
           , '/c': '/e509465ef513154988e088d6ad3c21bf/c'
+          , '/c_link': '/e509465ef513154988e088d6ad3c21bf/c_link'
           , '/sub/a': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a'
+          , '/sub/a_link': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a_link'
           }
 
         a.should.eql(results)
@@ -130,6 +131,6 @@ describe('versionator', function() {
   })
 
   after(function(done) {
-    removeFiles(tmpPath, files, done)
+    removeFiles(tmpPath, files, dirs, done)
   })
 })


### PR DESCRIPTION
`createMapFromPath(dir)` crashes when dir contains (or is) a symlink to a directory. The crash is the result of trying to calculate the hash of a directory.
The reason is: while file walking, directories are filtered but not  symlinks to directories. This pull request add the extra check and associated unit tests. It also filters other non-regular files (FIFO, character devices, etc.).

Reproducing the problem:

```
mkdir dir
ln -s dir symlink
```

Then

```
var versionator = require("versionator");
versionator,createMapFromPath("dir", function(){}); //No problem
versionator,createMapFromPath("symlink", function(){}); //Problem
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: EISDIR, read
```
