### PR TITLE
Follow symlinks while walking down the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ versionator.createMapFromPath(__dirname + '/public', function(error, staticFileM
 ```
 If you use the helper you can switch methods without any changes to your view code.
 
+The symlinks will be followed unless you using the following option:
+
+```js
+
+versionator.createMapFromPath(__dirname + './public', { followLinks: false },
+function(error, staticFileMap) { ... } )`
+
+```
+
 ### Live map updates
 
 You can modify the map at runtime, say if during development you want to do a live reload of a resource. First, get the hash map for the modified files by passing a list of files as a `fileList` parameter. This should be full file paths and the files should be in the original public directory. The directory is passed in as well. Then pass the the new hash map to the middleware via `modifyMap`. Then push the new url to the client and update the resource tag to cause a reload.

--- a/lib/map-path.js
+++ b/lib/map-path.js
@@ -4,11 +4,68 @@ var url = require('url')
   , fs = require('fs')
   , path = require('path')
   , extend = require('lodash.assign')
-  , walker = require('walker')
+  , walk = require('walk').walk
+
+function hash(filename, callback) {
+  var md5sum = crypto.createHash('md5')
+
+  fs.ReadStream(filename)
+  .on('data', function(d) {
+    md5sum.update(d)
+  })
+  .on('end', function() {
+    callback(undefined, md5sum.digest('hex'))
+  })
+}
+
+function makeHashMap (files, dirPath, callback) {
+  var hashMap = Object.create(null)
+  async.forEach(files, function(filename, fileCallback) {
+
+    // resolve '../'s
+    filename = path.resolve(filename)
+
+    hash(filename, function(error, fileHash) {
+
+      var urlPath = filename.substring(dirPath.length + 1)
+        , normalizedPath = path.normalize('/' + urlPath).replace(/\\/g, '/')
+        , pos = normalizedPath.lastIndexOf('/')
+
+      hashMap[normalizedPath] =
+        normalizedPath.substring(0, pos) + '/' + fileHash +
+        normalizedPath.substring(pos) || url
+
+      fileCallback(error)
+    })
+  }, function(error) {
+    if (error) {
+      return callback(error)
+    }
+    callback(undefined, hashMap)
+  })
+}
+
+function getFilesList(dirPath, options, callback) {
+  var files = []
+  if (options.fileList) {
+    for (var i in options.fileList) {
+      files.push(options.fileList[i])
+    }
+    callback(files)
+  } else {
+    var followLinks = options.followLinks != null ? options.followLinks : true
+    walk(dirPath, { followLinks: followLinks })
+    .on('file', function(dir, stat, next) {
+      files.push(dir + '/' + stat.name)
+      next()
+    })
+    .on('end', function() {
+      callback(files)
+    })
+  }
+}
 
 module.exports = function(dirPath, params, callback) {
-
-  var files = []
 
   if ((callback === undefined) && (typeof params === 'function')) {
     callback = params
@@ -31,70 +88,8 @@ module.exports = function(dirPath, params, callback) {
     dirPath = dirPath.slice(0, -1);
   }
 
-  function hash(filename, callback) {
-    var md5sum = crypto.createHash('md5')
-      , s = fs.ReadStream(filename)
-
-    s.on('data', function(d) {
-      md5sum.update(d)
-    })
-
-    s.on('end', function() {
-      callback(undefined, md5sum.digest('hex'))
-    })
-  }
-
-  function makeHashMap (callback) {
-    var hashMap = Object.create(null)
-    async.forEach(files, function(filename, fileCallback) {
-
-      // resolve '../'s
-      filename = path.resolve(filename)
-
-      hash(filename, function(error, fileHash) {
-
-        var urlPath = path.normalize('/' + filename.substring(dirPath.length + 1)).replace(/\\/g, '/')
-          , pos = urlPath.lastIndexOf('/')
-
-        hashMap[urlPath] =
-          urlPath.substring(0, pos) + '/' + fileHash +
-          urlPath.substring(pos) || url
-
-        fileCallback(error)
-      })
-    }, function(error) {
-      if (error) {
-        return callback(error)
-      }
-      callback(undefined, hashMap)
-    })
-  }
-
-  if (options.fileList) {
-    for (var i in options.fileList) {
-      files.push(options.fileList[i])
-    }
-    makeHashMap(callback)
-    return
-  }
-
-  walker(dirPath)
-
-  .on('file', function(filename) {
-    files.push(filename)
+  getFilesList(dirPath, options, function(files) {
+    makeHashMap(files, dirPath, callback)
   })
-  .on('symlink', function(filename) {
-    files.push(filename)
-  })
-  .on('end', function() {
-    // Remove symlinks to directories, since directories should not be hashed
-    async.filter(files, function(filename,callback) {
-      fs.stat(filename, function(error, stat) {
-        callback(stat.isFile())
-      })
-    }, function(filteredFiles) {
-      files = filteredFiles
-      makeHashMap(callback)
-    })
-  })
+
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "lodash.assign": "^2.4.1",
-    "walker": "^1.0.6"
+    "walk": "^2.3.9"
   },
   "devDependencies": {
     "express": "~2.5",

--- a/test/map-path.test.js
+++ b/test/map-path.test.js
@@ -12,10 +12,10 @@ function createFiles(dirPath, files, dirs, callback) {
     fns.push(async.apply(fs.writeFile, dirPath + '/' + filename, files[filename]))
   })
   Object.keys(files).forEach(function(filename) {
-    fns.push(async.apply(fs.symlink, dirPath + '/' + filename, dirPath + '/' + filename + '_link'))
+    fns.push(async.apply(fs.symlink, dirPath + '/' + filename, dirPath + '/' + filename + '_lnk'))
   });
   dirs.forEach(function(dir) {
-    fns.push(async.apply(fs.symlink, dirPath + '/' + dir, dirPath + '/' + dir + '_link'))
+    fns.push(async.apply(fs.symlink, dirPath + '/' + dir, dirPath + '/' + dir + '_lnk'))
   });
   async.series(fns, callback)
 }
@@ -27,10 +27,10 @@ function removeFiles(dirPath, files, dirs, callback) {
     fns.push(async.apply(fs.unlink, dirPath + '/' + filename))
   })
   Object.keys(files).forEach(function(filename) {
-    fns.push(async.apply(fs.unlink, dirPath + '/' + filename + '_link'))
+    fns.push(async.apply(fs.unlink, dirPath + '/' + filename + '_lnk'))
   })
   dirs.forEach(function(dir) {
-    fns.push(async.apply(fs.unlink, dirPath + '/' + dir + '_link'))
+    fns.push(async.apply(fs.unlink, dirPath + '/' + dir + '_lnk'))
   });
 
   fns.push(async.apply(fs.rmdir, dirPath + '/sub'))
@@ -69,13 +69,31 @@ describe('versionator', function() {
 
         var a =
           { '/a': '/d41d8cd98f00b204e9800998ecf8427e/a'
-          , '/a_link': '/d41d8cd98f00b204e9800998ecf8427e/a_link'
+          , '/a_lnk': '/d41d8cd98f00b204e9800998ecf8427e/a_lnk'
           , '/b': '/8b1a9953c4611296a827abf8c47804d7/b'
-          , '/b_link': '/8b1a9953c4611296a827abf8c47804d7/b_link'
+          , '/b_lnk': '/8b1a9953c4611296a827abf8c47804d7/b_lnk'
           , '/c': '/e509465ef513154988e088d6ad3c21bf/c'
-          , '/c_link': '/e509465ef513154988e088d6ad3c21bf/c_link'
+          , '/c_lnk': '/e509465ef513154988e088d6ad3c21bf/c_lnk'
           , '/sub/a': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a'
-          , '/sub/a_link': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a_link'
+          , '/sub/a_lnk': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a_lnk'
+          , '/sub_lnk/a': '/sub_lnk/49f68a5c8493ec2c0bf489821c21fc3b/a'
+          , '/sub_lnk/a_lnk': '/sub_lnk/49f68a5c8493ec2c0bf489821c21fc3b/a_lnk'
+          }
+        a.should.eql(results)
+
+        done()
+      })
+
+    })
+
+    it('should not follow symlinks if specified', function(done) {
+      versionator.createMapFromPath(tmpPath, { followLinks: false }, function(error, results) {
+
+        var a =
+          { '/a': '/d41d8cd98f00b204e9800998ecf8427e/a'
+          , '/b': '/8b1a9953c4611296a827abf8c47804d7/b'
+          , '/c': '/e509465ef513154988e088d6ad3c21bf/c'
+          , '/sub/a': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a'
           }
         a.should.eql(results)
 
@@ -111,13 +129,15 @@ describe('versionator', function() {
 
         var a =
           { '/a': '/d41d8cd98f00b204e9800998ecf8427e/a'
-          , '/a_link': '/d41d8cd98f00b204e9800998ecf8427e/a_link'
+          , '/a_lnk': '/d41d8cd98f00b204e9800998ecf8427e/a_lnk'
           , '/b': '/8b1a9953c4611296a827abf8c47804d7/b'
-          , '/b_link': '/8b1a9953c4611296a827abf8c47804d7/b_link'
+          , '/b_lnk': '/8b1a9953c4611296a827abf8c47804d7/b_lnk'
           , '/c': '/e509465ef513154988e088d6ad3c21bf/c'
-          , '/c_link': '/e509465ef513154988e088d6ad3c21bf/c_link'
+          , '/c_lnk': '/e509465ef513154988e088d6ad3c21bf/c_lnk'
           , '/sub/a': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a'
-          , '/sub/a_link': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a_link'
+          , '/sub/a_lnk': '/sub/49f68a5c8493ec2c0bf489821c21fc3b/a_lnk'
+          , '/sub_lnk/a': '/sub_lnk/49f68a5c8493ec2c0bf489821c21fc3b/a'
+          , '/sub_lnk/a_lnk': '/sub_lnk/49f68a5c8493ec2c0bf489821c21fc3b/a_lnk'
           }
 
         a.should.eql(results)


### PR DESCRIPTION
At the moment, versionator does not follow symlinks.
Following symlinks is useful e.g. when the dist/ folder is filled with symlinks to the src/ folder (which is my case). 
Since node-walker cannot follow symlinks, I replaced it with node-walk (which seems to include more features and be more actively maintained as well), added test cases and an option to createMapFromPath() which disallows following symlinks.